### PR TITLE
Add VS Code Devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+FROM mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye
+
+# Install additional packages.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends curl jq \
+    && apt-get -y install ca-certificates curl python3-pip python3-dev python3-setuptools python3-wheel \
+    && pip install --upgrade pip && pip install requests \
+    && sudo rm -rf /var/lib/apt/lists/*
+    
+RUN curl -o pond https://raw.githubusercontent.com/Team-Kujira/pond/main/pond && chmod +x pond && sudo mv pond /usr/local/bin/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 		"context": ".."
     },
 
-	"forwardPorts": [10117, 10157],
+	"forwardPorts": [10117, 10157, 5173],
 
 	"postCreateCommand": "pond init && pond start && npm i",
 	"features": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+	"name": "Node.hs, TypeScript & Pond",
+    "build": {
+        "dockerfile": "Dockerfile",
+		"context": ".."
+    },
+
+	"forwardPorts": [10117, 10157],
+
+	"postCreateCommand": "pond init && pond start && npm i",
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
+	}
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/README.md
+++ b/README.md
@@ -22,3 +22,18 @@ Load the config into your pond-ui app
 
 - Wallet connections
 - Transaction signing & broadcasting
+
+## Dev Containers
+
+To open the repository in a VS Code Devcontainer:
+- Use VS Code on your local machine
+- Install the [Dev Containers VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+- Click on the bottom left and choose to Reopen in Container
+
+[!WARNING]
+Do not use it in Github Codespaces as the Kujira apps will not see it at the required IP Addresses
+
+This will install:
+1. Pond
+2. Typescript
+3. npm

--- a/README.md
+++ b/README.md
@@ -31,9 +31,6 @@ To open the repository in a VS Code Devcontainer:
 - Click on the bottom left and choose to Reopen in Container
 - Execute `npm run dev` and you are ready to build
 
-[!WARNING]
-Do not use it in Github Codespaces as the Kujira apps will not see it at the required IP Addresses
-
 This will install:
 1. Pond
 2. Typescript

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ To open the repository in a VS Code Devcontainer:
 - Use VS Code on your local machine
 - Install the [Dev Containers VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
 - Click on the bottom left and choose to Reopen in Container
+- Execute `npm run dev` and you are ready to build
 
 [!WARNING]
 Do not use it in Github Codespaces as the Kujira apps will not see it at the required IP Addresses


### PR DESCRIPTION
Adds:
1. Pond initialized and started
2. Type Script
3. npm

Also updated README to include the instructions to use it in a VS Code devcontainer